### PR TITLE
Add CORS support to handle OPTIONS request

### DIFF
--- a/webserver/server.py
+++ b/webserver/server.py
@@ -8,6 +8,10 @@ class Server(BaseHTTPRequestHandler):
     def do_HEAD(self):
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
 
     def do_GET(self):
@@ -52,10 +56,7 @@ class Server(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
         self.send_response(200)
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
-        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.do_HEAD()
         self.end_headers()
 
     def send_file(self, path):

--- a/webserver/server.py
+++ b/webserver/server.py
@@ -50,6 +50,14 @@ class Server(BaseHTTPRequestHandler):
         else:
             self.resource_not_found()
 
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
     def send_file(self, path):
         try:
             file = open(path, mode='rb')

--- a/webserver/server.py
+++ b/webserver/server.py
@@ -1,3 +1,4 @@
+import mimetypes
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 host_port = 8000
@@ -7,7 +8,8 @@ class Server(BaseHTTPRequestHandler):
 
     def do_HEAD(self):
         self.send_response(200)
-        self.send_header('Content-type', 'text/html')
+        mimetype, _ = mimetypes.guess_type(self.path)
+        self.send_header('Content-type', mimetype)
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
         self.send_header("Access-Control-Allow-Headers", "X-Requested-With")


### PR DESCRIPTION
When doing a POST request from javascript it does an OPTIONS request first, that request must be responded before sending the actual POST request, I got the code from [Here](https://stackoverflow.com/questions/16583827/cors-with-python-basehttpserver-501-unsupported-method-options-in-chrome/32501309)